### PR TITLE
Allow to return IPv6 address for A-record request

### DIFF
--- a/DNSAgent/DnsAgent.cs
+++ b/DNSAgent/DnsAgent.cs
@@ -322,7 +322,8 @@ namespace DnsAgent
                                     }
                                     else if (ip.AddressFamily == AddressFamily.InterNetworkV6)
                                     {
-                                        if (question.RecordType == RecordType.Aaaa)
+                                        if (question.RecordType == RecordType.Aaaa ||
+                                            (Rules[i].ReturnOnARequest != null && Rules[i].ReturnOnARequest.Value))
                                             message.AnswerRecords.Add(new AaaaRecord(question.Name, 600, ip));
                                         else
                                             continue;

--- a/DNSAgent/DnsAgent.cs
+++ b/DNSAgent/DnsAgent.cs
@@ -313,12 +313,20 @@ namespace DnsAgent
                                 }
                                 else
                                 {
-                                    if (question.RecordType == RecordType.A &&
-                                        ip.AddressFamily == AddressFamily.InterNetwork)
-                                        message.AnswerRecords.Add(new ARecord(question.Name, 600, ip));
-                                    else if (question.RecordType == RecordType.Aaaa &&
-                                             ip.AddressFamily == AddressFamily.InterNetworkV6)
-                                        message.AnswerRecords.Add(new AaaaRecord(question.Name, 600, ip));
+                                    if (ip.AddressFamily == AddressFamily.InterNetwork)
+                                    {
+                                        if (question.RecordType == RecordType.A)
+                                            message.AnswerRecords.Add(new ARecord(question.Name, 600, ip));
+                                        else
+                                            continue;
+                                    }
+                                    else if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+                                    {
+                                        if (question.RecordType == RecordType.Aaaa)
+                                            message.AnswerRecords.Add(new AaaaRecord(question.Name, 600, ip));
+                                        else
+                                            continue;
+                                    }
                                     else // Type mismatch
                                         continue;
 

--- a/DNSAgent/Rule.cs
+++ b/DNSAgent/Rule.cs
@@ -34,6 +34,11 @@ namespace DnsAgent
         public int? QueryTimeout { get; set; } = null;
 
         /// <summary>
+        ///     Whether to force to return an (IPv6) address even when client requests a record with type A.
+        /// </summary>
+        public bool? ReturnOnARequest { get; set; } = null;
+
+        /// <summary>
         ///     Whether to enable compression pointer mutation to query this name server. If "Address" is set, this will be
         ///     ignored.
         /// </summary>


### PR DESCRIPTION
Add an option item only for special rules, so that
some may get IPv6 address and visit IPv6 websites normally, if:
* IPv6 on top-priority network adapter is disabled
* Other adapter(s) have IPv6 protocol enabled.

Originally, Windows will not try to request any Aaaa record
if meeting the above, which will prevent users to take advantage
of their IPv6 networks. And this PR is a work-around for it.

This breaks some specification, but is indeed useful.